### PR TITLE
Set PGBouncer to ignore extra_float_digits flag.

### DIFF
--- a/templates/pgbouncer.ini.erb
+++ b/templates/pgbouncer.ini.erb
@@ -13,6 +13,7 @@ listen_addr = <%= @listen_addr %>
 listen_port = <%= @listen_port %>
 unix_socket_dir = /var/run/postgresql
 auth_type = <%= @auth_type %>
+ignore_startup_parameters = extra_float_digits
 <% if @auth_type == 'hba' %>
 auth_hba_file = <%= @_hba_file %>
 <% end %>


### PR DESCRIPTION
This is a problem because many PG drivers hardcode this value into
their connection strings making them incompatible with PGBouncer
